### PR TITLE
Fix deprecation notice for sys_language_uid

### DIFF
--- a/Configuration/TCA/tx_cetimeline_domain_model_entry.php
+++ b/Configuration/TCA/tx_cetimeline_domain_model_entry.php
@@ -48,17 +48,7 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.language',
             'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'special' => 'languages',
-                'items' => [
-                    [
-                        'LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages',
-                        -1,
-                        'flags-multiple'
-                    ]
-                ],
-                'default' => 0,
+                'type' => 'language',
             ],
         ],
         'l10n_parent' => [


### PR DESCRIPTION
> The TCA field 'sys_language_uid' of table 'tx_cetimeline_domain_model_entry' is defined
> as the 'languageField' and should therefore use the TCA type 'language'
> instead of TCA type 'select' with 'foreign_table=sys_language' or 'special=languages'

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.2/Feature-57082-NewTCATypeLanguage.html