### PR TITLE
Re-add "replaces" for old extension name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         "chronologisch",
         "chronologic"
     ],
+    "replace": {
+        "simonkoehler/ce-timeline": "self.version"
+    },
     "extra": {
         "typo3/cms": {
             "extension-key": "ce_timeline"


### PR DESCRIPTION
The following commit changed the package name:
> Udpate composer vendor name from "simonkoehler" to "fullstackfreelancer"

composer.json now declares that the new name replaces the old one.