### PR TITLE
Fix deprecation: showRecordFieldList not needed anymore

### DIFF
--- a/Configuration/TCA/tx_cetimeline_domain_model_entry.php
+++ b/Configuration/TCA/tx_cetimeline_domain_model_entry.php
@@ -23,9 +23,6 @@ return [
         ],
         'iconfile' => 'EXT:ce_timeline/Resources/Public/Icons/content-timeline-record.svg',
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, header, header_layout, description, description_html, position, typeof, media, starttime, endtime',
-    ],
     'types' => [
         '1' => ['showitem' => 'l10n_parent, l10n_diffsource, --palette--;;settings, --palette--;;titles, description, description_html, --div--;Galerie, --palette--;;dimensions,--palette--;;lightbox, --div--;Access, starttime, endtime'],
     ],


### PR DESCRIPTION
> The 'tx_cetimeline_domain_model_entry' TCA configuration 'showRecordFieldList'
> inside the section 'interface' is not evaluated anymore and should therefore be removed.

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html